### PR TITLE
PubSub redux for ChannelPoint PoC

### DIFF
--- a/bot/bot.go
+++ b/bot/bot.go
@@ -6,6 +6,7 @@ import (
 	"sync"
 )
 
+// Bot handles various feature processing based on Stream events
 type Bot struct {
 	sync.Mutex
 
@@ -21,11 +22,6 @@ type Bot struct {
 	// events
 	events    chan Event
 	listening bool
-}
-
-// Client represents data being sent TO the Bot
-type Client interface {
-	SetDestination(chan<- Event)
 }
 
 func New() Bot {

--- a/bot/channelPointHandler.go
+++ b/bot/channelPointHandler.go
@@ -1,0 +1,15 @@
+package bot
+
+import (
+	"fmt"
+	log "medgebot/logger"
+)
+
+// RegisterChannelPointHandler responds to Channel Point redemption messages
+func (bot *Bot) RegisterChannelPointHandler() {
+	bot.RegisterHandler(
+		NewHandler(func(evt Event) {
+			log.Info(fmt.Sprintf("%+v", evt))
+		}),
+	)
+}

--- a/bot/client.go
+++ b/bot/client.go
@@ -1,0 +1,6 @@
+package bot
+
+// Client represents data being sent TO the Bot
+type Client interface {
+	SetDestination(chan<- Event)
+}

--- a/config.yaml
+++ b/config.yaml
@@ -8,9 +8,6 @@ medgelabs:
     ledger:
       expirationTime: 43200 # 12 hours
     messageFormat: "Welcome to the lab, @{{.Sender}}!"
-  channelPoints:
-    enabled: false
-    messageFormat: "Thanks for the research @{{.Sender}}!"
   raids:
     enabled: true
     delaySeconds: 2
@@ -24,6 +21,12 @@ medgelabs:
   giftsubs:
     enabled: true
     messageFormat: "@{{.Sender}} loaned their lab coat to @{{.Recipient}}!"
+  channelPoints:
+    enabled: false
+    mappings:
+      - title: "Waste your Points"
+        type: "response"
+        messageFormat: "Thanks for donating your credits to the Lab Bots!"
   commands:
     enabled: true
     known:

--- a/config/config.go
+++ b/config/config.go
@@ -35,6 +35,12 @@ func New(channel string, configPath string) (Config, error) {
 	}, nil
 }
 
+// ChannelID returns the numeric ChannelID for the current broadcaster
+func (c *Config) ChannelID() string {
+	channelID := c.config.GetString(c.key("channelId"))
+	return channelID
+}
+
 // Nick returns the nickname to join IRC with
 func (c *Config) Nick() string {
 	nick := c.config.GetString(c.key("nick"))

--- a/config/config.go
+++ b/config/config.go
@@ -105,13 +105,19 @@ func (c *Config) GreetMessageFormat() string {
 	return msgFormat
 }
 
+// ChannelPointsEnabled checks the Commands feature flag
+func (c *Config) ChannelPointsEnabled() bool {
+	flagValue := c.config.GetBool(c.key("channelPoints.enabled"))
+	return flagValue
+}
+
 // CommandsEnabled checks the Commands feature flag
 func (c *Config) CommandsEnabled() bool {
 	flagValue := c.config.GetBool(c.key("commands.enabled"))
 	return flagValue
 }
 
-// KnownCommands returns a slice of map[prefix]message pairs, to be parsed elsewhere,
+// KnownCommand returns a slice of map[prefix]message pairs, to be parsed elsewhere,
 // that represent commands the Bot responds to
 type KnownCommand struct {
 	Prefix  string `mapstructure:"prefix"`

--- a/go.mod
+++ b/go.mod
@@ -3,6 +3,7 @@ module medgebot
 go 1.15
 
 require (
+	github.com/buger/jsonparser v1.1.1
 	github.com/fsnotify/fsnotify v1.4.9 // indirect
 	github.com/gorilla/websocket v1.4.2
 	github.com/kr/pretty v0.2.1 // indirect

--- a/go.sum
+++ b/go.sum
@@ -23,6 +23,8 @@ github.com/beorn7/perks v0.0.0-20180321164747-3a771d992973/go.mod h1:Dwedo/Wpr24
 github.com/beorn7/perks v1.0.0/go.mod h1:KWe93zE9D1o94FZ5RNwFwVgaQK1VOXiVxmqh+CedLV8=
 github.com/bgentry/speakeasy v0.1.0/go.mod h1:+zsyZBPWlz7T6j88CTgSN5bM796AkVf0kBD4zp0CCIs=
 github.com/bketelsen/crypt v0.0.3-0.20200106085610-5cbc8cc4026c/go.mod h1:MKsuJmJgSg28kpZDP6UIiPt0e0Oz0kqKNGyRaWEPv84=
+github.com/buger/jsonparser v1.1.1 h1:2PnMjfWD7wBILjqQbt530v576A/cAbQvEW9gGIpYMUs=
+github.com/buger/jsonparser v1.1.1/go.mod h1:6RYKKt7H4d4+iWqouImQ9R2FZql3VbhNgx27UK13J/0=
 github.com/cespare/xxhash v1.1.0/go.mod h1:XrSqR1VqqWfGrhpAt58auRo0WTKS1nRRg3ghfAqPWnc=
 github.com/client9/misspell v0.3.4/go.mod h1:qj6jICC3Q7zFZvVWo7KLAzC3yx5G7kyvSDkc90ppPyw=
 github.com/coreos/bbolt v1.3.2/go.mod h1:iRUV2dpdMOn7Bo10OQBFzIJO9kkE559Wcmn+qkEiiKk=

--- a/main.go
+++ b/main.go
@@ -95,7 +95,7 @@ func main() {
 	pubsub := pubsub.NewClient(pubSubWs, conf.ChannelID(), password)
 	pubsub.Start()
 	// defer pubsub.Close()
-	// chatBot.RegisterClient(irc)
+	chatBot.RegisterClient(pubsub)
 
 	// Feature Toggles
 	if conf.CommandsEnabled() || enableAll {

--- a/main.go
+++ b/main.go
@@ -85,17 +85,20 @@ func main() {
 	chatBot.RegisterClient(irc)
 	chatBot.SetChatClient(irc)
 
-	// PubSub
-	pubSubWs := ws.NewWebsocket()
-	err = pubSubWs.Connect("wss", "pubsub-edge.twitch.tv")
-	if err != nil {
-		log.Fatal("pubsub ws connect", err)
-	}
+	// TODO pubsub is only used for ChannelPoints at this time.
+	// If we use pubsub for other features, it wouldn't make sense to
+	// guard pubsub creation behind this feature flag
+	if conf.ChannelPointsEnabled() || enableAll {
+		pubSubWs := ws.NewWebsocket()
+		err = pubSubWs.Connect("wss", "pubsub-edge.twitch.tv")
+		if err != nil {
+			log.Fatal("pubsub ws connect", err)
+		}
 
-	pubsub := pubsub.NewClient(pubSubWs, conf.ChannelID(), password)
-	pubsub.Start()
-	// defer pubsub.Close()
-	chatBot.RegisterClient(pubsub)
+		pubsub := pubsub.NewClient(pubSubWs, conf.ChannelID(), password)
+		pubsub.Start()
+		chatBot.RegisterClient(pubsub)
+	}
 
 	// Feature Toggles
 	if conf.CommandsEnabled() || enableAll {

--- a/pubsub/channelPoint.go
+++ b/pubsub/channelPoint.go
@@ -1,0 +1,31 @@
+package pubsub
+
+import "time"
+
+// ChannelPointRedemption represents a ChannelPoint message from PubSub,
+// cut down to the data we need
+type ChannelPointRedemption struct {
+	Type string `json:"type"`
+	Data struct {
+		Redemption struct {
+			ID   string `json:"id"`
+			User struct {
+				ID          string `json:"id"`
+				Login       string `json:"login"`
+				DisplayName string `json:"display_name"`
+			} `json:"user"`
+			ChannelID  string    `json:"channel_id"`
+			RedeemedAt time.Time `json:"redeemed_at"`
+			Reward     struct {
+				ID        string `json:"id"`
+				Title     string `json:"title"`
+				Prompt    string `json:"prompt"`
+				Cost      int    `json:"cost"`
+				IsEnabled bool   `json:"is_enabled"`
+				IsPaused  bool   `json:"is_paused"`
+				IsInStock bool   `json:"is_in_stock"`
+			} `json:"reward"`
+			UserInput string `json:"user_input"`
+		} `json:"redemption"`
+	} `json:"data"`
+}

--- a/pubsub/pubsub.go
+++ b/pubsub/pubsub.go
@@ -130,7 +130,8 @@ func (client *PubSub) read() error {
 		return errors.New("Empty message buffer")
 	}
 
-	str := string(buff)
+	// Trim null bytes for print cleanliness
+	str := string(bytes.Trim(buff, "\x00"))
 	log.Info("PubSub: " + str)
 
 	// First, we extract the type to see what we're receiving

--- a/pubsub/pubsub.go
+++ b/pubsub/pubsub.go
@@ -184,7 +184,13 @@ func (client *PubSub) read() error {
 }
 
 func (client *PubSub) handleChannelPointRedemption(msg ChannelPointRedemption) {
-	log.Info(fmt.Sprintf("%+v", msg))
+	evt := bot.NewPointsEvent()
+	evt.Title = msg.Data.Redemption.Reward.Title
+	evt.Sender = msg.Data.Redemption.User.DisplayName
+	evt.Amount = msg.Data.Redemption.Reward.Cost
+	evt.Message = msg.Data.Redemption.UserInput
+
+	client.outboundEvents <- evt
 }
 
 // Write writes a message to the PubSub stream
@@ -201,4 +207,11 @@ func (client *PubSub) write(message interface{}) error {
 	json.NewEncoder(&buf).Encode(message)
 	_, err := client.conn.Write(buf.Bytes())
 	return err
+}
+
+// bot.Client
+
+// SetDestination sets the outbound channel for bot.Events the client will send to the bot
+func (client *PubSub) SetDestination(outbound chan<- bot.Event) {
+	client.outboundEvents = outbound
 }

--- a/pubsub/pubsub.go
+++ b/pubsub/pubsub.go
@@ -1,0 +1,178 @@
+package pubsub
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"io"
+	"medgebot/bot"
+	log "medgebot/logger"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/pkg/errors"
+)
+
+const (
+	// MaxMessageSize defines the maximum size of a message that can be received.
+	// This is used to size the message buffer slice for the io.Read method
+	MaxMessageSize = 2048 // bytes
+
+	// PingInterval for the Ping/Pong loop
+	PingInterval = 4 * time.Minute
+
+	ChannelPointTopic = "channel-points-channel-v1"
+)
+
+// PubSub wraps the websocket connection to Twitch PubSub and acts as a
+// Producer of ChannelPoint messages. We do NOT send messages to PubSub
+type PubSub struct {
+	sync.Mutex
+	conn           io.ReadWriteCloser
+	outboundEvents chan<- bot.Event
+
+	// For reconnect purposes
+	channelID    string
+	authToken    string
+	serverScheme string
+	serverHost   string
+}
+
+// NewClient creates a non-connected Client
+func NewClient(conn io.ReadWriteCloser, channelID, authToken string) *PubSub {
+	return &PubSub{
+		conn:      conn,
+		channelID: channelID,
+		authToken: authToken,
+	}
+}
+
+// Start actually connects to PubSub and starts the read loops
+func (client *PubSub) Start() error {
+	// Read loop for receiving messages
+	go func() {
+		for {
+			if err := client.read(); err != nil {
+				log.Error("pubsub read", err)
+				break
+			}
+		}
+	}()
+
+	// Subscribe to ChannelPointRedemption messages
+	if err := client.listen("channel-points-channel-v1"); err != nil {
+		return err
+	}
+
+	// Lastly, ensure we heartbeat with PubSub
+	go client.ping()
+
+	return nil
+}
+
+// Listen fires off a request to listen to the given topics
+func (client *PubSub) listen(topic string) error {
+	type topicRequest struct {
+		Type  string `json:"type"`
+		Nonce string `json:"nonce"`
+		Data  struct {
+			Topics    []string `json:"topics"`
+			AuthToken string   `json:"auth_token"`
+		} `json:"data"`
+	}
+
+	topicStr := fmt.Sprintf("%s.%s", topic, client.channelID)
+	log.Info("PubSub: LISTEN " + topicStr)
+	return client.write(topicRequest{
+		Type: "LISTEN",
+		Data: struct {
+			Topics    []string `json:"topics"`
+			AuthToken string   `json:"auth_token"`
+		}{
+			Topics:    []string{topicStr},
+			AuthToken: client.authToken,
+		},
+	})
+}
+
+// Ping sends a PING message every 4 minutes
+func (client *PubSub) ping() {
+	ticker := time.NewTicker(PingInterval)
+
+	go func() {
+		for range ticker.C {
+			ping := struct {
+				Type string `json:"type"`
+			}{
+				Type: "PING",
+			}
+
+			log.Info("PubSub: PING")
+			if err := client.write(ping); err != nil {
+				log.Error("pubsub ping", err)
+			}
+		}
+	}()
+}
+
+// Read reads from the PubSub stream
+func (client *PubSub) read() error {
+	buff := make([]byte, MaxMessageSize)
+	len, err := client.conn.Read(buff)
+	if err != nil {
+		return errors.Wrap(err, "read pubsub")
+	}
+
+	if len == 0 {
+		log.Warn("Empty message buffer from PubSub")
+		return errors.New("Empty message buffer")
+	}
+
+	str := string(buff)
+	log.Info("PubSub: " + str)
+
+	// TODO determine if Ping/Pong or other before parsing
+	var envelope struct {
+		Type string `json:"type"`
+		Data struct {
+			Topic   string          `json:"topic"`
+			Message json.RawMessage // to delay processing
+		} `json:"data"`
+	}
+
+	err = json.Unmarshal(buff, &envelope)
+	if err != nil {
+		return errors.Wrap(err, "pubsub message parse")
+	}
+
+	// ChannelPoints
+	if strings.HasPrefix(envelope.Data.Topic, ChannelPointTopic) {
+		var channelPoints ChannelPointRedemption
+		err = json.Unmarshal(envelope.Data.Message, &channelPoints)
+
+		client.handleChannelPointRedemption(channelPoints)
+	}
+
+	return nil
+}
+
+func (client *PubSub) handleChannelPointRedemption(msg ChannelPointRedemption) {
+	log.Info(fmt.Sprintf("%+v", msg))
+}
+
+// Write writes a message to the PubSub stream
+func (client *PubSub) write(message interface{}) error {
+	if client.conn == nil {
+		return errors.Errorf("PubSub.conn is nil")
+	}
+
+	// Lock since we must only allow one concurrent write
+	client.Mutex.Lock()
+	defer client.Mutex.Unlock()
+
+	var buf bytes.Buffer
+	json.NewEncoder(&buf).Encode(message)
+	_, err := client.conn.Write(buf.Bytes())
+	return err
+}

--- a/pubsub/pubsub_test.go
+++ b/pubsub/pubsub_test.go
@@ -1,0 +1,89 @@
+package pubsub
+
+import (
+	"fmt"
+	"medgebot/bot"
+	"medgebot/ws/wstest"
+	"testing"
+	"time"
+)
+
+func TestMessageReceivedFromServer(t *testing.T) {
+	conn := wstest.NewWebsocket()
+	channelID := "testChannelID"
+	authToken := "testAuthToken"
+
+	client := NewClient(conn, channelID, authToken)
+	testBot := make(chan bot.Event)
+	client.SetDestination(testBot)
+	client.Start()
+
+	// Cursed be json-stringified `message` >.>
+	conn.Send(fmt.Sprintf(`{
+	  "type": "MESSAGE",
+	  "data": {
+		  "topic": "%s.%s",
+		  "message": "{
+			\"type\": \"reward-redeemed\",
+			\"data\": {
+			  \"timestamp\": \"2019-11-12T01:29:34.98329743Z\",
+			  \"redemption\": {
+				\"id\": \"9203c6f0-51b6-4d1d-a9ae-8eafdb0d6d47\",
+				\"user\": {
+				  \"id\": \"30515034\",
+				  \"login\": \"testUser\",
+				  \"display_name\": \"testUser\"
+				},
+				\"channel_id\": \"testChannelID\",
+				\"redeemed_at\": \"2021-02-10T18:52:53.128421623Z\",
+				\"reward\": {
+				  \"id\": \"6ef17bb2-e5ae-432e-8b3f-5ac4dd774668\",
+				  \"channel_id\": \"testChannelID\",
+				  \"title\": \"Hydrate!\",
+				  \"prompt\": \"\",
+				  \"cost\": 10,
+				  \"is_user_input_required\": false,
+				  \"is_sub_only\": false,
+				  \"image\": {
+					\"url_1x\": \"https://static-cdn.jtvnw.net/custom-reward-images/30515034/6ef17bb2-e5ae-432e-8b3f-5ac4dd774668/7bcd9ca8-da17-42c9-800a-2f08832e5d4b/custom-1.png\",
+					\"url_2x\": \"https://static-cdn.jtvnw.net/custom-reward-images/30515034/6ef17bb2-e5ae-432e-8b3f-5ac4dd774668/7bcd9ca8-da17-42c9-800a-2f08832e5d4b/custom-2.png\",
+					\"url_4x\": \"https://static-cdn.jtvnw.net/custom-reward-images/30515034/6ef17bb2-e5ae-432e-8b3f-5ac4dd774668/7bcd9ca8-da17-42c9-800a-2f08832e5d4b/custom-4.png\"
+				  },
+				  \"default_image\": {
+					\"url_1x\": \"https://static-cdn.jtvnw.net/custom-reward-images/default-1.png\",
+					\"url_2x\": \"https://static-cdn.jtvnw.net/custom-reward-images/default-2.png\",
+					\"url_4x\": \"https://static-cdn.jtvnw.net/custom-reward-images/default-4.png\"
+				  },
+				  \"background_color\": \"#00C7AC\",
+				  \"is_enabled\": true,
+				  \"is_paused\": false,
+				  \"is_in_stock\": true,
+				  \"max_per_stream\": { \"is_enabled\": false, \"max_per_stream\": 0 },
+				  \"should_redemptions_skip_request_queue\": true
+				},
+				\"user_input\": \"\",
+				\"status\": \"FULFILLED\"
+			  }
+			}
+		 }"
+	  }`, ChannelPointTopic, channelID))
+
+	// Wait for message on bot Event channel
+	select {
+	case evt := <-testBot:
+		if evt.Type != bot.POINT_REDEMPTION {
+			t.Fatalf("Did not receive a ChannelPoint message. Got %+v", evt)
+		}
+
+		if evt.Amount != 10 {
+			t.Fatalf("Did not receive the correct event Amount. Got %d", evt.Amount)
+		}
+
+		if evt.Title != "Hydrate!" {
+			t.Fatalf("Did not receive the correct event Title. Got %s", evt.Title)
+		}
+	case <-time.After(3 * time.Second):
+		fmt.Println(conn.String())
+		t.Fatalf("Timeout while waiting to receive expected message")
+	}
+}

--- a/ws/wstest/websocket.go
+++ b/ws/wstest/websocket.go
@@ -7,12 +7,15 @@ import (
 	"time"
 )
 
+// Websocket stubs a ws connection and keeps track of messages sent/received
+// with convenience methods for Tests. Does NOT communicate on the network
 type Websocket struct {
 	sync.Mutex
 	lines      []string
 	readCursor int
 }
 
+// NewWebsocket returns a new, fresh Websocket stub
 func NewWebsocket() *Websocket {
 	return &Websocket{
 		lines:      make([]string, 0),
@@ -25,7 +28,7 @@ func (w *Websocket) Send(message string) {
 	w.Write([]byte(message))
 }
 
-// Send is a convenience method over Write() that also waits
+// SendAndWait is a convenience method over Write() that also waits
 // for a new message to arrive
 func (w *Websocket) SendAndWait(message string) {
 	w.Write([]byte(message))
@@ -71,7 +74,7 @@ func (w *Websocket) String() string {
 
 // io.ReadWriteCloser
 func (w *Websocket) Read(dst []byte) (int, error) {
-	// Block until lines available?
+	// Block until lines available
 	for {
 		if len(w.lines) != 0 && w.readCursor < len(w.lines) {
 			break


### PR DESCRIPTION
* Add PubSub client back to handle ChannelPoint redemptions
* Add jsonparser lib for easier JSON extraction in PubSub due to wonky JSON differences
* Move bot.Client to its own file, since it's being implemented by multiple clients now
* Add channelPointHandler in the bot, only logging redemption for now

TODO:

* Tests for channelPointHandler